### PR TITLE
Minimize C++ warnings from spamming compiler output.

### DIFF
--- a/desmume/src/path.h
+++ b/desmume/src/path.h
@@ -400,7 +400,7 @@ public:
 				else if (strchr(strftimeArgs, *p))
 				{
 					char tmp[MAX_PATH];
-					char format[] = { '%', *p, NULL };
+					char format[] = { '%', *p, '\0' };
 					strftime(tmp, MAX_PATH, format, time_struct);
 					file.append(tmp);
 		}


### PR DESCRIPTION
Currently this software builds only if `X432R_CUSTOMRENDERER_ENABLED=0` is set in the GNU makefile.

It doesn't build otherwise yet--we haven't gotten to the bottom of that, but there are plenty of warnings on the side even if the source does compile and link.  Since they got in the way of studying the compiler output (and continue to suggest hazardous, possibly even broken emulation code), I wanted to centralize/eliminate the warnings to key spots where the compiler didn't fill up my window with them so much.

The first commit was easy.
The second commit took a while--not only did I move the warnings to pre-organized assignments to pointer variables, but this allowed me to rewrite many things in array-index form.  It should be easier to flatten and staticize some of these `switch` statements to use the expression being `switch`'d on as a direct input to static code instead of throwing in an unconditional branch like that.  Maybe in the future if I find room to make a commit like that the sound-processing in Desmume here could get faster.

The cause of 95% of the remaining warnings is that non-pointer integers (e.g. unsigned int, char ...) are being used as pointers or pointer offsets...when these things could have just been declared as pointers to begin with.  I didn't want to make a major fundamental change like that because I don't yet understand how much that would affect, so I wanted to organize everything like this first.
