### PR TITLE
More repairs to frequent warnings and some build errors.

### DIFF
--- a/desmume/src/NDSSystem.cpp
+++ b/desmume/src/NDSSystem.cpp
@@ -460,8 +460,12 @@ bool GameInfo::loadROM(std::string fname, u32 type)
 
 		if (type == ROM_NDS)
 		{
+			size_t elements_read;
+
 			fseek(fROM, 0x4000 + headerOffset, SEEK_SET);
-			fread(&secureArea[0], 1, 0x4000, fROM);
+			elements_read = fread(&secureArea[0], 1, 0x4000, fROM);
+			if (elements_read != 0x4000)
+				printf("Unexpectedly short post-header bit.\n");
 		}
 
 		if (CommonSettings.loadToMemory)
@@ -497,8 +501,13 @@ bool GameInfo::loadROM(std::string fname, u32 type)
 		_isDSiEnhanced = ((readROM(0x180) == 0x8D898581U) && (readROM(0x184) == 0x8C888480U));
 		if (hasRomBanner())
 		{
+			size_t elements_read;
+			const size_t elements_to_read = sizeof(RomBanner);
+
 			fseek(fROM, header.IconOff + headerOffset, SEEK_SET);
-			fread(&banner, 1, sizeof(RomBanner), fROM);
+			elements_read = fread(&banner, 1, elements_to_read, fROM);
+			if (elements_read != elements_to_read)
+				printf("Unexpectedly short post-header bit.\n");
 			
 			banner.version = LE_TO_LOCAL_16(banner.version);
 			banner.crc16 = LE_TO_LOCAL_16(banner.crc16);

--- a/desmume/src/debug.cpp
+++ b/desmume/src/debug.cpp
@@ -220,7 +220,7 @@ void DEBUG_reset()
 
 	DEBUG_Notify = DebugNotify();
 	DEBUG_statistics = DebugStatistics();
-	printf("DEBUG_reset: %08X\n",&DebugStatistics::print); //force a reference to this function
+	printf("DEBUG_reset: %p\n", &DebugStatistics::print); //force a reference to this function
 }
 
 static void DEBUG_dumpMemory_fill(EMUFILE *fp, u32 size)

--- a/desmume/src/libretro/libretro.cpp
+++ b/desmume/src/libretro/libretro.cpp
@@ -42,9 +42,11 @@ namespace X432R
 	#endif
 	
 	CRITICAL_SECTION customFrontBufferSync;
+#ifdef HAVE_OPENGL
 //	static GLuint screenTexture[2] = {0};
 	static GLuint screenTexture = 0;
 	static GLuint hudTexture = 0;
+#endif
 	static u32 lastRenderMagnification = 1;
 	
 	HighResolutionFramebuffers backBuffer;
@@ -1280,7 +1282,9 @@ namespace X432R
 		
 		// `æJn
 		const RGBA8888 clearcolor = (u32)ScreenGapColor;
+#ifdef HAVE_OPENGL
 		const GLuint texture_filter = ( GetStyle() & DWS_FILTER ) ? GL_LINEAR : GL_NEAREST;
+#endif
 		
 		glDisable(GL_LIGHTING);
 		glDisable(GL_DEPTH_TEST);
@@ -1395,8 +1399,11 @@ namespace X432R
 	}
 	
 #ifdef HAVE_OPENGL
-//	inline GLuint GetScreenTexture()
+#if 0
+	inline GLuint GetScreenTexture()
+#else
 	inline u32 GetScreenTexture()
+#endif
 	{
 		if(screenTexture == 0)
 			glGenTextures(1, &screenTexture);

--- a/desmume/src/utils/vfat.cpp
+++ b/desmume/src/utils/vfat.cpp
@@ -75,7 +75,7 @@ static void list_files(const char *filepath, ListCallback list_callback)
 	if (dwError != FS_ERR_NO_MORE_FILES) return;
 }
 
-static u64 dataSectors = 0;
+static unsigned long dataSectors = 0;
 void count_ListCallback(FsEntry* fs, EListCallbackArg arg)
 {
 	if(arg == EListCallbackArg_Pop) return;
@@ -180,7 +180,10 @@ bool VFAT::build(const char* path, int extra_MB)
 
 	if(dataSectors>=(0x80000000>>9))
 	{
-		printf("error allocating memory for fat (%d KBytes)\n",(dataSectors*512)/1024);
+		printf(
+			"error allocating memory for fat (%lu KBytes)\n",
+			(dataSectors*512) / 1024
+		);
 		printf("total fat sizes > 2GB are never going to work\n");
 	}
 	
@@ -191,7 +194,10 @@ bool VFAT::build(const char* path, int extra_MB)
 	}
 	catch(std::bad_alloc)
 	{
-		printf("error allocating memory for fat (%d KBytes)\n",(dataSectors*512)/1024);
+		printf(
+			"error allocating memory for fat (%lu KBytes)\n",
+			(dataSectors*512) / 1024
+		);
 		printf("(out of memory)\n");
 		return false;
 	}

--- a/desmume/src/utils/vfat.cpp
+++ b/desmume/src/utils/vfat.cpp
@@ -132,11 +132,21 @@ void build_ListCallback(FsEntry* fs, EListCallbackArg arg)
 		FILE* inf = fopen(path.c_str(),"rb");
 		if(inf)
 		{
-			fseek(inf,0,SEEK_END);
-			long len = ftell(inf);
-			fseek(inf,0,SEEK_SET);
-			u8 *buf = new u8[len];
-			fread(buf,1,len,inf);
+			u8 * buf;
+			size_t elements_read;
+			long len;
+
+			fseek(inf, 0, SEEK_END);
+			len = ftell(inf);
+			fseek(inf, 0, SEEK_SET);
+			buf = new u8[len];
+			elements_read = fread(buf, 1, len, inf);
+			if (elements_read != len)
+				printf(
+					"libfat:  %lu bytes read instead of %l.\n",
+					elements_read,
+					len
+				);
 			fclose(inf);
 
 			std::string path = currVirtPath + "/" + fname;
@@ -147,7 +157,6 @@ void build_ListCallback(FsEntry* fs, EListCallbackArg arg)
 			delete[] buf;
 		} else printf("ERROR opening file for fat\n");
 	}
-		
 }
 
 


### PR DESCRIPTION
When `X432R_CUSTOMRENDERER_ENABLED=1` some build errors relating to DirectDraw, OpenGL and Win32 code not being filtered appropriately have been fixed.  I discovered more warnings when trying to compile in this mode on 64-bit Linux/GNU.

There may be more new warnings on this environment when disabling said makefile parameter, but my Internet is about to shut down, so...kept to a single PR.
