### PR TITLE
Fix win32 build

### DIFF
--- a/desmume/src/types.h
+++ b/desmume/src/types.h
@@ -82,7 +82,9 @@
 #define strncasecmp(x, y, l) strnicmp(x, y, l)
 #define snprintf _snprintf
 #else
+#ifndef _WIN32
 #define WINAPI
+#endif
 #endif
 
 #if !defined(MAX_PATH)


### PR DESCRIPTION
We are not msvc but still win32 and undefining WINAPI produces all kinds of ugly compiler and linker errors.

This fixes win32 building and linking for me.
