### PR TITLE
Fixed debug build, don't strip on debug Windows build

### DIFF
--- a/desmume/Makefile.libretro
+++ b/desmume/Makefile.libretro
@@ -1,3 +1,4 @@
+DEBUG=0
 X432R_CUSTOMRENDERER_ENABLED=0
 
 ifeq ($(platform),)
@@ -193,13 +194,15 @@ else ifneq (,$(findstring armv,$(platform)))
 	endif
 	CXXFLAGS += -DARM
 
-
 # Windows
 else
 	TARGET := $(TARGET_NAME)_libretro.dll
 	CC = gcc
 	CXX = g++
-	SHARED := -shared -static-libgcc -static-libstdc++ -s -Wl,--version-script=$(CORE_DIR)/libretro/link.T
+	SHARED := -shared -static-libgcc -static-libstdc++ -Wl,--version-script=$(CORE_DIR)/libretro/link.T
+	ifeq ($(DEBUG), 0)
+		SHARED += -s
+	endif
 	DESMUME_JIT = 1
 	HAVE_DIRENT_WIN = 1
 
@@ -215,7 +218,6 @@ endif
 
 include Makefile.common
 
-DEBUG=0
 ifeq ($(DEBUG), 1)
 	CXXFLAGS += -g -O0
 else


### PR DESCRIPTION
`DEBUG` was being set after Makefile.libretro was read, preventing a few files that had the necessary symbols from being compiled and causing linker errors.

I have also changed Windows builds to only strip symbols when `DEBUG=0`. With symbols stripped, source information was lost making debugging a pain.
