### PR TITLE
Set default JIT block size to 12, fix Castlevania: Dawn of Sorrow iss…

### DIFF
--- a/desmume/src/libretro/libretro.cpp
+++ b/desmume/src/libretro/libretro.cpp
@@ -358,7 +358,7 @@ static void check_variables(bool first_boot)
 
     if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
         CommonSettings.jit_max_block_size = var.value ? strtol(var.value, 0, 10) : 100;
-   else
+    else
         CommonSettings.jit_max_block_size = 100;
 #endif
 
@@ -645,7 +645,7 @@ void retro_set_environment(retro_environment_t cb)
 #else
       { "desmume_cpu_mode", "CPU mode; jit|interpreter" },
 #endif
-      { "desmume_jit_block_size", "JIT block size; 100|99|98|97|96|95|94|93|92|91|90|89|88|87|86|85|84|83|82|81|80|79|78|77|76|75|74|73|72|71|70|69|68|67|66|65|64|63|62|61|60|59|58|57|56|55|54|53|52|51|50|49|48|47|46|45|44|43|42|41|40|39|38|37|36|35|34|33|32|31|30|29|28|27|26|25|24|23|22|21|20|19|18|17|16|15|14|13|12|11|10|9|8|7|6|5|4|3|2|1|0" },
+      { "desmume_jit_block_size", "JIT block size; 12|11|10|9|8|7|6|5|4|3|2|1|0|100|99|98|97|96|95|94|93|92|91|90|89|88|87|86|85|84|83|82|81|80|79|78|77|76|75|74|73|72|71|70|69|68|67|66|65|64|63|62|61|60|59|58|57|56|55|54|53|52|51|50|49|48|47|46|45|44|43|42|41|40|39|38|37|36|35|34|33|32|31|30|29|28|27|26|25|24|23|22|21|20|19|18|17|16|15|14|13" },
 #else
       { "desmume_cpu_mode", "CPU mode; interpreter" },
 #endif


### PR DESCRIPTION
…ues. It should be the safest value for more games, but maybe it'll hit the performance a little.

See: https://sourceforge.net/p/desmume/bugs/1275/
