### PR TITLE
Report git version with library_version

### DIFF
--- a/desmume/Makefile.libretro
+++ b/desmume/Makefile.libretro
@@ -17,6 +17,10 @@ endif
 
 TARGET_NAME := desmume
 CORE_DIR := src
+GIT_VERSION := " $(shell git rev-parse --short HEAD || echo unknown)"
+ifneq ($(GIT_VERSION)," unknown")
+	CXXFLAGS += -DGIT_VERSION=\"$(GIT_VERSION)\"
+endif
 
 # Unix
 ifneq (,$(findstring unix,$(platform)))

--- a/desmume/src/libretro/jni/Android.mk
+++ b/desmume/src/libretro/jni/Android.mk
@@ -4,6 +4,11 @@ LOCAL_PATH := $(call my-dir)
 
 include $(CLEAR_VARS)
 
+GIT_VERSION := " $(shell git rev-parse --short HEAD || echo unknown)"
+ifneq ($(GIT_VERSION)," unknown")
+	LOCAL_CXXFLAGS += -DGIT_VERSION=\"$(GIT_VERSION)\"
+endif
+
 CORE_DIR = ../..
 JIT=
 DESMUME_JIT=0

--- a/desmume/src/libretro/libretro.cpp
+++ b/desmume/src/libretro/libretro.cpp
@@ -349,7 +349,11 @@ namespace
 void retro_get_system_info(struct retro_system_info *info)
 {
    info->library_name = "DeSmuME";
+#ifdef GIT_VERSION
+   info->library_version = "git" GIT_VERSION;
+#else
    info->library_version = "SVN";
+#endif
    info->valid_extensions = "nds|bin";
    info->need_fullpath = true;
    info->block_extract = false;


### PR DESCRIPTION
This patch makes this core report the git version along with its library_version. This is important because otherwise it is impossible to replicate a build without extra knowledge, and things like Netplay that demand versions be the same can't be reliably known to work.