### PR TITLE
libretro: Fix compilation with DEBUG=1 (missing include)

### DIFF
--- a/desmume/src/debug.cpp
+++ b/desmume/src/debug.cpp
@@ -28,6 +28,7 @@
 #include "NDSSystem.h"
 #include "utils/xstring.h"
 #include "movie.h"
+#include "emufile.h"
 
 armcpu_t* TDebugEventData::cpu() { return procnum==0?&NDS_ARM9:&NDS_ARM7; }
 


### PR DESCRIPTION
EMUFILE was forward declared but never included:

```
src/debug.cpp:239:4: error: invalid use of incomplete type ‘class EMUFILE’
  fp->fseek(0xF00000,SEEK_SET); fp->fwrite(MMU.SWIRAM,0x8000); //arm9/arm7 shared WRAM (32KB)
    ^
In file included from src/debug.cpp:19:0:
src/debug.h:31:7: note: forward declaration of ‘class EMUFILE’
 class EMUFILE;
       ^
src/debug.cpp:239:34: error: invalid use of incomplete type ‘class EMUFILE’
  fp->fseek(0xF00000,SEEK_SET); fp->fwrite(MMU.SWIRAM,0x8000); //arm9/arm7 shared WRAM (32KB)
```