### PR TITLE
Silence -fpermissive warnings

### DIFF
--- a/desmume/Makefile.libretro
+++ b/desmume/Makefile.libretro
@@ -300,7 +300,7 @@ CFLAGS      += -std=gnu99 -D__LIBRETRO__ $(fpic) $(COMMON_DEFINES)
 
 ifeq (,$(findstring msvc,$(platform)))
 CXXFLAGS += -fpermissive
-CFLAGS   += -fpermissive
+CFLAGS   +=
 endif
 
 OBJOUT   = -o


### PR DESCRIPTION
Silences the following warnings with `gcc-7.1.0`.
```
cc -std=gnu99 -D__LIBRETRO__ -fPIC  -Isrc/libretro-common/include -Isrc -Isrc/libretro   -fpermissive -c -osrc/utils/libfat/partition.o src/utils/libfat/partition.c
cc1: warning: command line option ‘-fpermissive’ is valid for C++/ObjC++ but not for C
cc -std=gnu99 -D__LIBRETRO__ -fPIC  -Isrc/libretro-common/include -Isrc -Isrc/libretro   -fpermissive -c -osrc/utils/libfat/cache.o src/utils/libfat/cache.c
cc1: warning: command line option ‘-fpermissive’ is valid for C++/ObjC++ but not for C
cc -std=gnu99 -D__LIBRETRO__ -fPIC  -Isrc/libretro-common/include -Isrc -Isrc/libretro   -fpermissive -c -osrc/utils/libfat/directory.o src/utils/libfat/directory.c
cc1: warning: command line option ‘-fpermissive’ is valid for C++/ObjC++ but not for C
cc -std=gnu99 -D__LIBRETRO__ -fPIC  -Isrc/libretro-common/include -Isrc -Isrc/libretro   -fpermissive -c -osrc/utils/libfat/disc.o src/utils/libfat/disc.c
cc1: warning: command line option ‘-fpermissive’ is valid for C++/ObjC++ but not for C
cc -std=gnu99 -D__LIBRETRO__ -fPIC  -Isrc/libretro-common/include -Isrc -Isrc/libretro   -fpermissive -c -osrc/utils/libfat/fatdir.o src/utils/libfat/fatdir.c
cc1: warning: command line option ‘-fpermissive’ is valid for C++/ObjC++ but not for C
In file included from src/utils/libfat/fatdir.c:48:0:
src/utils/libfat/fatdir.h:71:71: warning: ‘struct statvfs’ declared inside parameter list will not be visible outside of this definition or declaration
 extern int _FAT_statvfs_r (struct _reent *r, const char *path, struct statvfs *buf);
                                                                       ^~~~~~~
cc -std=gnu99 -D__LIBRETRO__ -fPIC  -Isrc/libretro-common/include -Isrc -Isrc/libretro   -fpermissive -c -osrc/utils/libfat/fatfile.o src/utils/libfat/fatfile.c
cc -std=gnu99 -D__LIBRETRO__ -fPIC  -Isrc/libretro-common/include -Isrc -Isrc/libretro   -fpermissive -c -osrc/utils/libfat/filetime.o src/utils/libfat/filetime.c
cc1: warning: command line option ‘-fpermissive’ is valid for C++/ObjC++ but not for C
cc1: warning: command line option ‘-fpermissive’ is valid for C++/ObjC++ but not for C
cc -std=gnu99 -D__LIBRETRO__ -fPIC  -Isrc/libretro-common/include -Isrc -Isrc/libretro   -fpermissive -c -osrc/utils/libfat/file_allocation_table.o src/utils/libfat/file_allocation_table.c
cc1: warning: command line option ‘-fpermissive’ is valid for C++/ObjC++ but not for C
cc -std=gnu99 -D__LIBRETRO__ -fPIC  -Isrc/libretro-common/include -Isrc -Isrc/libretro   -fpermissive -c -osrc/utils/libfat/libfat.o src/utils/libfat/libfat.c
cc1: warning: command line option ‘-fpermissive’ is valid for C++/ObjC++ but not for C
In file included from src/utils/libfat/libfat.c:35:0:
src/utils/libfat/fatdir.h:71:71: warning: ‘struct statvfs’ declared inside parameter list will not be visible outside of this definition or declaration
 extern int _FAT_statvfs_r (struct _reent *r, const char *path, struct statvfs *buf);
                                                                       ^~~~~~~
cc -std=gnu99 -D__LIBRETRO__ -fPIC  -Isrc/libretro-common/include -Isrc -Isrc/libretro   -fpermissive -c -osrc/utils/libfat/libfat_public_api.o src/utils/libfat/libfat_public_api.c
cc -std=gnu99 -D__LIBRETRO__ -fPIC  -Isrc/libretro-common/include -Isrc -Isrc/libretro   -fpermissive -c -osrc/utils/libfat/lock.o src/utils/libfat/lock.c
cc1: warning: command line option ‘-fpermissive’ is valid for C++/ObjC++ but not for C
cc1: warning: command line option ‘-fpermissive’ is valid for C++/ObjC++ but not for C
cc -std=gnu99 -D__LIBRETRO__ -fPIC  -Isrc/libretro-common/include -Isrc -Isrc/libretro   -fpermissive -c -osrc/libretro-common/rthreads/rthreads.o src/libretro-common/rthreads/rthreads.c
cc1: warning: command line option ‘-fpermissive’ is valid for C++/ObjC++ but not for C
cc -std=gnu99 -D__LIBRETRO__ -fPIC  -Isrc/libretro-common/include -Isrc -Isrc/libretro   -fpermissive -c -osrc/common.o src/common.c
cc -std=gnu99 -D__LIBRETRO__ -fPIC  -Isrc/libretro-common/include -Isrc -Isrc/libretro   -fpermissive -c -osrc/utils/dlditool.o src/utils/dlditool.c
cc1: warning: command line option ‘-fpermissive’ is valid for C++/ObjC++ but not for C
cc1: warning: command line option ‘-fpermissive’ is valid for C++/ObjC++ but not for C
cc -std=gnu99 -D__LIBRETRO__ -fPIC  -Isrc/libretro-common/include -Isrc -Isrc/libretro   -fpermissive -c -osrc/libretro-common/memmap/memalign.o src/libretro-common/memmap/memalign.c
cc1: warning: command line option ‘-fpermissive’ is valid for C++/ObjC++ but not for C
cc -std=gnu99 -D__LIBRETRO__ -fPIC  -Isrc/libretro-common/include -Isrc -Isrc/libretro   -fpermissive -c -osrc/libretro-common/streams/file_stream.o src/libretro-common/streams/file_stream.c
cc1: warning: command line option ‘-fpermissive’ is valid for C++/ObjC++ but not for C
cc -std=gnu99 -D__LIBRETRO__ -fPIC  -Isrc/libretro-common/include -Isrc -Isrc/libretro   -fpermissive -c -osrc/libretro-common/features/features_cpu.o src/libretro-common/features/features_cpu.c
cc -std=gnu99 -D__LIBRETRO__ -fPIC  -Isrc/libretro-common/include -Isrc -Isrc/libretro   -fpermissive -c -osrc/libretro-common/compat/compat_strl.o src/libretro-common/compat/compat_strl.c
cc1: warning: command line option ‘-fpermissive’ is valid for C++/ObjC++ but not for C
cc1: warning: command line option ‘-fpermissive’ is valid for C++/ObjC++ but not for C
cc -std=gnu99 -D__LIBRETRO__ -fPIC  -Isrc/libretro-common/include -Isrc -Isrc/libretro   -fpermissive -c -osrc/libretro-common/file/retro_dirent.o src/libretro-common/file/retro_dirent.c
cc1: warning: command line option ‘-fpermissive’ is valid for C++/ObjC++ but not for C
cc -std=gnu99 -D__LIBRETRO__ -fPIC  -Isrc/libretro-common/include -Isrc -Isrc/libretro   -fpermissive -c -osrc/libretro-common/file/retro_stat.o src/libretro-common/file/retro_stat.c
cc1: warning: command line option ‘-fpermissive’ is valid for C++/ObjC++ but not for C
cc -std=gnu99 -D__LIBRETRO__ -fPIC  -Isrc/libretro-common/include -Isrc -Isrc/libretro   -fpermissive -c -osrc/libretro-common/file/file_path.o src/libretro-common/file/file_path.c
cc1: warning: command line option ‘-fpermissive’ is valid for C++/ObjC++ but not for C
cc -std=gnu99 -D__LIBRETRO__ -fPIC  -Isrc/libretro-common/include -Isrc -Isrc/libretro   -fpermissive -c -osrc/libretro-common/string/stdstring.o src/libretro-common/string/stdstring.c
cc1: warning: command line option ‘-fpermissive’ is valid for C++/ObjC++ but not for C
cc -std=gnu99 -D__LIBRETRO__ -fPIC  -Isrc/libretro-common/include -Isrc -Isrc/libretro   -fpermissive -c -osrc/version.o src/version.c
cc1: warning: command line option ‘-fpermissive’ is valid for C++/ObjC++ but not for C
```