### PR TITLE
ci: add a Linux aarch64 build

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,6 +26,10 @@ include:
   # Linux 64-bit
   - project: 'libretro-infrastructure/ci-templates'
     file: '/linux-x64.yml'
+
+  # Linux ARM 64-bit
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/linux-aarch64.yml'
     
   ################################## CELLULAR ################################
   # Android
@@ -68,6 +72,12 @@ libretro-build-windows-i686:
 libretro-build-linux-x64:
   extends:
     - .libretro-linux-x64-make-default
+    - .core-defs
+
+# Linux ARM 64-bit
+libretro-build-linux-aarch64:
+  extends:
+    - .libretro-linux-aarch64-make-default
     - .core-defs
     
 ################################### CELLULAR #################################

--- a/desmume/Makefile.libretro
+++ b/desmume/Makefile.libretro
@@ -61,6 +61,12 @@ ifneq (,$(findstring unix,$(platform)))
          CXXFLAGS += -mfloat-abi=hard
       endif
       CXXFLAGS += -DARM
+   else ifneq (,$(filter aarch64 arm64,$(shell uname -m)))
+      # AArch64 (ARM64): no dynarec backend available (AsmJit is x86-only and the
+      # arm_arm JIT is 32-bit ARM only), so build the interpreter core.
+      ARCH = arm64
+      DESMUME_JIT = 0
+      DESMUME_JIT_ARM = 0
    else
       DESMUME_JIT ?= 1
    endif


### PR DESCRIPTION
The libretro buildbot ships no aarch64 Linux build of DeSmuME 2015, so the core can't be installed from RetroArch's Core Downloader on ARM64 Linux machines (ARM Chromebooks, SBCs, ARM laptops).

This needs two changes, the same pair that libretro/desmume#124 needed:

**1. `desmume/Makefile.libretro`** - don't enable the x86 dynarec on ARM64. On `platform=unix` the ARM check only matches 32-bit (`findstring armv,$(platform)`), so an aarch64 host falls into the `else` branch and gets `DESMUME_JIT ?= 1`, i.e. the AsmJit x86 recompiler. That can't work on ARM64 (and `DESMUME_JIT_ARM` is the 32-bit ARM dynarec, so it's no help either), so build the interpreter:

```make
   else ifneq (,$(filter aarch64 arm64,$(shell uname -m)))
      # AArch64 (ARM64): no dynarec backend available (AsmJit is x86-only and the
      # arm_arm JIT is 32-bit ARM only), so build the interpreter core.
      ARCH = arm64
      DESMUME_JIT = 0
      DESMUME_JIT_ARM = 0
```

This mirrors what `jni/Android.mk` already does for arm64-v8a.

**2. `.gitlab-ci.yml`** - the job itself:

```yaml
# Linux ARM 64-bit
libretro-build-linux-aarch64:
  extends:
    - .libretro-linux-aarch64-make-default
    - .core-defs
```

plus the matching `/linux-aarch64.yml` template include. The file uses CRLF line endings; the patch keeps them.

Verified natively on aarch64 (postmarketOS on a Snapdragon 670 Chromebook, glibc, GCC 15): with the Makefile fix the build completes clean with no source changes, producing `desmume2015_libretro.so` (ELF 64-bit ARM aarch64). Running a commercial NDS ROM in a minimal libretro host it emulates 300 frames at 256x384 / 60 fps with correct audio pacing (735 frames per `retro_run` at 44100 Hz), at 58.2 fps - about 97% of realtime on this hardware, which is what you'd expect from the interpreter on a mid-range ARM chip.
